### PR TITLE
Fix splitfrag

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Signac
 Title: Analysis of Single-Cell Chromatin Data
-Version: 1.1.0.9003
+Version: 1.1.0.9004
 Date: 2020-11-24
 Authors@R: c(
   person(given = 'Tim', family = 'Stuart', email = 'tstuart@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0002-3044-0897')),

--- a/R/fragments.R
+++ b/R/fragments.R
@@ -148,6 +148,12 @@ SplitFragments <- function(
     group.by = group.by,
     idents = idents
   )
+  cat(groups)
+  cat("\n")
+  cat(paste("group by", group.by))
+  cat("\n")
+  cat(idents)
+  cat("\n")
   # replace space with underscore
   cells <- names(x = groups)
   groups <- gsub(pattern = " ", replacement = "_", x = groups)
@@ -161,6 +167,7 @@ SplitFragments <- function(
   # split cells from each fragment file
   # append to existing file when more than one fragment file used
   for (i in seq_along(along.with = frags)) {
+    cat(paste("i: ", i, "\n"))
     if (!append & (length(x = frags) > 1)) {
       suffix.use <- paste0(file.suffix, ".", i)
     } else {
@@ -177,6 +184,11 @@ SplitFragments <- function(
     if (verbose) {
       message("Processing file ", fragpath)
     }
+    cat(paste("fragments", fragpath, "\n"))
+    cat(paste("outdir", paste0(outdir, .Platform$file.sep), "\n"))
+    cat(paste("suffix", suffix.use , "\n"))
+    cat(paste("unique_idents", unique_idents , "\n"))
+    cat(paste("buffer_length", buffer_length , "\n"))
     splitfiles <- splitFragments(
       fragments = fragpath,
       outdir = paste0(outdir, .Platform$file.sep),

--- a/R/fragments.R
+++ b/R/fragments.R
@@ -148,12 +148,6 @@ SplitFragments <- function(
     group.by = group.by,
     idents = idents
   )
-  cat(groups)
-  cat("\n")
-  cat(paste("group by", group.by))
-  cat("\n")
-  cat(idents)
-  cat("\n")
   # replace space with underscore
   cells <- names(x = groups)
   groups <- gsub(pattern = " ", replacement = "_", x = groups)
@@ -167,7 +161,6 @@ SplitFragments <- function(
   # split cells from each fragment file
   # append to existing file when more than one fragment file used
   for (i in seq_along(along.with = frags)) {
-    cat(paste("i: ", i, "\n"))
     if (!append & (length(x = frags) > 1)) {
       suffix.use <- paste0(file.suffix, ".", i)
     } else {
@@ -184,11 +177,6 @@ SplitFragments <- function(
     if (verbose) {
       message("Processing file ", fragpath)
     }
-    cat(paste("fragments", fragpath, "\n"))
-    cat(paste("outdir", paste0(outdir, .Platform$file.sep), "\n"))
-    cat(paste("suffix", suffix.use , "\n"))
-    cat(paste("unique_idents", unique_idents , "\n"))
-    cat(paste("buffer_length", buffer_length , "\n"))
     splitfiles <- splitFragments(
       fragments = fragpath,
       outdir = paste0(outdir, .Platform$file.sep),

--- a/src/split.cpp
+++ b/src/split.cpp
@@ -34,20 +34,11 @@ int splitFragments(
   std::ofstream streams[unique_idents.size()];
   for (size_t i = 0; i < unique_idents.size(); i++) {
     std::string fileName = outdir + unique_idents[i] + suffix + ".bed";
-    //std::ofstream o_stream;
     if (append) {
       streams[i].open(fileName.c_str(), std::ios_base::app);
-      //streams.emplace_back(o_stream);
     } else {
       streams[i].open(fileName.c_str());
-      //streams.emplace_back(o_stream);
     }
-    // return 1 if it can't find the file
-    /*if (streams[i].fail()) {
-      Rcpp::Rcerr << "can't open file" << std::flush;
-      return 1;
-    }*/
-    
   }
 
   // return 1 if it can't find the file

--- a/src/split.cpp
+++ b/src/split.cpp
@@ -31,20 +31,22 @@ int splitFragments(
   gzFile ifileHandler = gzopen(fragments.c_str(), "rb");
 
   // open one output file for each unique ident
-  std::vector<std::ofstream> streams;
+  std::ofstream streams[unique_idents.size()];
   for (size_t i = 0; i < unique_idents.size(); i++) {
     std::string fileName = outdir + unique_idents[i] + suffix + ".bed";
-    std::ofstream o_stream;
+    //std::ofstream o_stream;
     if (append) {
-      streams.emplace_back(std::ofstream{ fileName.c_str(), std::ios_base::app});
+      streams[i].open(fileName.c_str(), std::ios_base::app);
+      //streams.emplace_back(o_stream);
     } else {
-      streams.emplace_back(std::ofstream{ fileName.c_str()});
+      streams[i].open(fileName.c_str());
+      //streams.emplace_back(o_stream);
     }
     // return 1 if it can't find the file
-    if (o_stream.fail()) {
+    /*if (streams[i].fail()) {
       Rcpp::Rcerr << "can't open file" << std::flush;
       return 1;
-    }
+    }*/
     
   }
 
@@ -128,7 +130,7 @@ int splitFragments(
 
   // Cleanup
   gzclose(ifileHandler);
-  for (int i = 0; i < streams.size(); i++) {
+  for (int i = 0; i < unique_idents.size(); i++) {
     streams[i].close();
   }
 

--- a/tests/testthat/test_fragments.R
+++ b/tests/testthat/test_fragments.R
@@ -133,8 +133,8 @@ test_that("SplitFragments works", {
   of1 <- paste0(tempdir(), .Platform$file.sep, "0.bed")
   of2 <- paste0(tempdir(), .Platform$file.sep, "1.bed")
 
-  bed1 <- read.table(file = of1, sep = "\t")
-  bed2 <- read.table(file = of2, sep = "\t")
+  bed1 <- read.table(file = of1, sep = "\t", stringsAsFactors = FALSE)
+  bed2 <- read.table(file = of2, sep = "\t", stringsAsFactors = FALSE)
 
   expect_equal(
     object = bed1,

--- a/tests/testthat/test_fragments.R
+++ b/tests/testthat/test_fragments.R
@@ -112,3 +112,130 @@ test_that("ValidateHash works", {
   )
   expect_true(object = valid)
 })
+
+test_that("SplitFragments works", {
+  fpath <- system.file("extdata", "fragments.tsv.gz", package="Signac")
+  cells <- colnames(x = atac_small)
+  names(x = cells) <- cells
+  frags <- CreateFragmentObject(
+    path = fpath,
+    cells = cells,
+    verbose = FALSE,
+    validate = FALSE
+  )
+  Fragments(atac_small) <- frags
+  SplitFragments(
+    object = atac_small,
+    assay = "peaks",
+    group.by = "seurat_clusters",
+    outdir = tempdir()
+  )
+  of1 <- paste0(tempdir(), .Platform$file.sep, "0.bed")
+  of2 <- paste0(tempdir(), .Platform$file.sep, "1.bed")
+
+  bed1 <- read.table(file = of1, sep = "\t")
+  bed2 <- read.table(file = of2, sep = "\t")
+
+  expect_equal(
+    object = bed1,
+    expected = structure(list(V1 = c("chr1", "chr1", "chr1", "chr1", "chr1",
+                                     "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1",
+                                     "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1",
+                                     "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1",
+                                     "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1",
+                                     "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1",
+                                     "chr1", "chr1", "chr1", "chr1"),
+                              V2 = c(10245L, 55313L, 56455L,
+                                     237741L, 241022L, 713591L, 713734L, 713751L, 713832L, 713934L,
+                                     714017L, 714017L, 714017L, 714028L, 714043L, 714043L, 714131L,
+                                     714140L, 714140L, 714182L, 714183L, 714241L, 714289L, 714454L,
+                                     714464L, 714597L, 752259L, 752682L, 752684L, 752699L, 752702L,
+                                     755549L, 762180L, 762531L, 762629L, 762652L, 762668L, 762718L,
+                                     762738L, 762811L, 762811L, 762845L, 762874L, 762927L, 770711L,
+                                     777349L, 778251L, 779103L, 779777L),
+                              V3 = c(10302L, 55699L, 56658L,
+                                     237772L, 241062L, 714040L, 714120L, 714035L, 714003L, 714035L,
+                                     714043L, 714092L, 714213L, 714145L, 714148L, 714178L, 714186L,
+                                     714174L, 714241L, 714284L, 714221L, 714345L, 714339L, 714485L,
+                                     714777L, 715147L, 752335L, 752837L, 752825L, 752877L, 752831L,
+                                     755587L, 762568L, 762907L, 762881L, 762938L, 762726L, 762904L,
+                                     762881L, 762864L, 762953L, 762881L, 762953L, 762972L, 771123L,
+                                     777590L, 778277L, 779346L, 780007L),
+                              V4 = c("AAAGATGAGGCTAAAT-1",
+                                     "AAACTCGTCTGGCACG-1", "AAACTCGTCTGGCACG-1", "AAAGGATTCCTTACGC-1",
+                                     "AAAGATGAGAAGGGCG-1", "AAACTCGCAGCGTCGT-1", "AAACGAATCCTTACGC-1",
+                                     "AAAGGATCATGGAGGT-1", "AAACTGCAGAATCAAC-1", "AAAGATGCAAGTCTGT-1",
+                                     "AAACTGCCATGTATCG-1", "AAAGGATTCCTTACGC-1", "AAACTGCCAAGCCAGA-1",
+                                     "AAAGGATTCTATGAGC-1", "AAACTGCAGCTCCATA-1", "AAAGATGAGTCCAGAG-1",
+                                     "AAACTGCTCATTCATC-1", "AAACGAAAGCGAGCTA-1", "AAACTCGGTGGATTCT-1",
+                                     "AAACTCGTCTGGCACG-1", "AAAGATGTCTAGCAGT-1", "AAACTGCGTACTAGAA-1",
+                                     "AAAGATGAGGCTAAAT-1", "AAAGATGAGGCTAAAT-1", "AAAGATGTCCTGAAAC-1",
+                                     "AAAGGATCAAGGGAGG-1", "AAACTCGGTGGATTCT-1", "AAAGGATTCTATGAGC-1",
+                                     "AAAGGATGTCCCTTTG-1", "AAAGATGCATGACTGT-1", "AAAGATGAGAAGGGCG-1",
+                                     "AAAGATGCAGCGTCGT-1", "AAACGAAGTTGTATCG-1", "AAACTCGCATGTGGGA-1",
+                                     "AAACTGCGTGCTGAAG-1", "AAAGATGCAAGTCTGT-1", "AAAGATGCATGACTGT-1",
+                                     "AAACTGCTCTGAGTAC-1", "AAACTCGAGTCACGCC-1", "AAAGGATTCCAACCTC-1",
+                                     "AAACGAAAGCGAGCTA-1", "AAAGGATTCTATGAGC-1", "AAACGAAAGCGAGCTA-1",
+                                     "AAAGATGAGTCCAGAG-1", "AAACTCGAGTCACGCC-1", "AAAGGATCAAGGGAGG-1",
+                                     "AAAGATGTCCTGAAAC-1", "AAACTCGCATGTGGGA-1", "AAAGATGAGGCTAAAT-1"
+                                                                                                                         ),
+                              V5 = c(1L, 2L, 1L, 1L, 1L, 1L, 2L, 6L, 1L, 3L, 1L, 2L, 1L,
+                                     1L, 8L, 9L, 1L, 1L, 3L, 1L, 2L, 4L, 2L, 1L, 2L, 1L, 1L, 1L, 1L,
+                                     3L, 1L, 1L, 1L, 1L, 2L, 1L, 4L, 3L, 4L, 2L, 1L, 2L, 2L, 3L, 1L,
+                                     2L, 1L, 2L, 1L)), class = "data.frame", row.names = c(NA, -49L
+                                     ))
+  )
+
+  expect_equal(
+    object = bed2,
+    expected = structure(list(V1 = c("chr1", "chr1", "chr1", "chr1", "chr1",
+                                     "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1",
+                                     "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1",
+                                     "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1",
+                                     "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1",
+                                     "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1", "chr1",
+                                     "chr1", "chr1", "chr1", "chr1", "chr1", "chr1"),
+                              V2 = c(60687L,
+                                     235723L, 526949L, 565296L, 712868L, 713684L, 713752L, 713780L,
+                                     713783L, 713783L, 713856L, 713934L, 713944L, 713989L, 713990L,
+                                     714022L, 714027L, 714028L, 714040L, 714114L, 714125L, 714144L,
+                                     714190L, 714263L, 714464L, 722942L, 738117L, 752435L, 752651L,
+                                     752660L, 752688L, 753227L, 754851L, 757378L, 762083L, 762450L,
+                                     762629L, 762657L, 762778L, 762778L, 762801L, 762859L, 762892L,
+                                     762895L, 762923L, 762951L, 764656L, 773187L, 773225L, 778213L,
+                                     779523L),
+                              V3 = c(60726L, 235936L, 527161L, 565351L, 713146L,
+                                    714108L, 713990L, 713992L, 714025L, 714045L, 714048L, 714176L,
+                                    713997L, 714247L, 714322L, 714182L, 714214L, 714144L, 714108L,
+                                    714207L, 714193L, 714209L, 714335L, 714732L, 714573L, 723275L,
+                                    738167L, 752819L, 752827L, 752875L, 752772L, 753684L, 755017L,
+                                    757538L, 762426L, 762501L, 762982L, 762859L, 762836L, 763004L,
+                                    762830L, 762971L, 762994L, 762938L, 763111L, 763224L, 764836L,
+                                    773410L, 773453L, 778402L, 779769L),
+                              V4 = c("AAACTGCAGTCTGTGT-1",
+                                    "AAACTGCTCCTATCCG-1", "AAACGAAGTGCCCGAT-1", "AAACTGCAGTCTGTGT-1",
+                                    "AAACGAAAGGCTTCGC-1", "AAACGAAGTGCCCGAT-1", "AAACTGCTCCTATCCG-1",
+                                    "AAAGATGCACGTTACA-1", "AAAGATGTCCACACCT-1", "AAACGAAAGGCTTCGC-1",
+                                    "AAACTCGGTTTGATCG-1", "AAACTCGTCAGGTCTA-1", "AAACGAAAGGCTTCGC-1",
+                                    "AAACTGCGTGCATTCA-1", "AAACTGCTCCTATCCG-1", "AAACTCGAGTACTCTG-1",
+                                    "AAACTGCTCGTTCAGA-1", "AAAGGATGTCGTAATC-1", "AAACGAAGTCAGGCTC-1",
+                                    "AAAGATGTCCACACCT-1", "AAAGATGTCCACACCT-1", "AAACGAAAGGCTTCGC-1",
+                                    "AAAGGATCAGATGGCA-1", "AAACGAAAGGCTTCGC-1", "AAACTCGAGTACTCTG-1",
+                                    "AAAGATGCAGCACATT-1", "AAACTCGGTTTGATCG-1", "AAACTCGCAAAGAGAG-1",
+                                    "AAAGATGAGTCGACCC-1", "AAACTCGCATCACAGT-1", "AAACTGCCAACAAACA-1",
+                                    "AAACTCGTCCACTAGA-1", "AAAGATGCACGTTACA-1", "AAACGAAAGGCTTCGC-1",
+                                    "AAAGGATGTCTAAGAA-1", "AAAGGATAGAACCATA-1", "AAACTCGCATCACAGT-1",
+                                    "AAAGGATGTCTTAGCA-1", "AAACTCGCAAAGAGAG-1", "AAAGATGCACGTTACA-1",
+                                    "AAACTCGTCAGGTCTA-1", "AAAGGATCAGATGGCA-1", "AAACTCGAGCGCATTT-1",
+                                    "AAACTGCGTGCATTCA-1", "AAACTCGCAAAGAGAG-1", "AAACGAAAGGCTTCGC-1",
+                                    "AAACTCGGTTTGATCG-1", "AAACTCGGTTTGATCG-1", "AAACGAAAGGCTTCGC-1",
+                                    "AAAGATGCACGTTACA-1", "AAACTCGGTTTGATCG-1"),
+                              V5 = c(1L, 1L, 2L,
+                                    1L, 1L, 1L, 3L, 3L, 2L, 2L, 1L, 3L, 1L, 2L, 1L, 1L, 4L, 1L, 1L,
+                                    1L, 2L, 3L, 1L, 1L, 1L, 1L, 1L, 1L, 3L, 3L, 1L, 1L, 1L, 2L, 1L,
+                                    1L, 1L, 1L, 2L, 2L, 3L, 18L, 1L, 1L, 1L, 1L, 1L, 4L, 2L, 2L,
+                                                                                                                                      1L)),
+                         class = "data.frame", row.names = c(NA, -51L))
+  )
+  file.remove(of1, of2)
+})


### PR DESCRIPTION
Requires testing on gcc without c++11. Tested on gcc-9.3 only.