### PR TITLE
Fix peaknames

### DIFF
--- a/R/fragments.R
+++ b/R/fragments.R
@@ -151,7 +151,7 @@ SplitFragments <- function(
   # replace space with underscore
   cells <- names(x = groups)
   groups <- gsub(pattern = " ", replacement = "_", x = groups)
-  groups <- gsub(pattern = .Platform$file.sep, replacement = "-", x = groups)
+  groups <- gsub(pattern = .Platform$file.sep, replacement = "_", x = groups)
   names(x = groups) <- cells
   buffer_length <- as.integer(x = buffer_length)
   file.suffix <- as.character(x = file.suffix)

--- a/R/peaks.R
+++ b/R/peaks.R
@@ -96,7 +96,7 @@ CallPeaks.Seurat <- function(
       idents = idents
     )
     groups <- gsub(pattern = " ", replacement = "_", x = groups)
-    groups <- gsub(pattern = .Platform$file.sep, replacement = "-", x = groups)
+    groups <- gsub(pattern = .Platform$file.sep, replacement = "_", x = groups)
     unique.groups <- unique(x = groups)
 
     # call peaks on each split fragment file separately

--- a/R/peaks.R
+++ b/R/peaks.R
@@ -96,7 +96,7 @@ CallPeaks.Seurat <- function(
       idents = idents
     )
     groups <- gsub(pattern = " ", replacement = "_", x = groups)
-    groups <- gsub(pattern = .Platform$file.sep, replacement = "_", x = groups)
+    groups <- gsub(pattern = .Platform$file.sep, replacement = "-", x = groups)
     unique.groups <- unique(x = groups)
 
     # call peaks on each split fragment file separately
@@ -117,7 +117,7 @@ CallPeaks.Seurat <- function(
         extsize = extsize,
         shift = shift,
         additional.args = additional.args,
-        name = name,
+        name = unique.groups[[i]],
         cleanup = cleanup,
         verbose = verbose
       )


### PR DESCRIPTION
 - #346 changed '/' to '_' in peaks but '-' in `SplitFragments', changing to '-' for consistency
- celltype specific peaks are now saved with `group.by` names and not the project name 
