### PR TITLE
Added explicit error message before peak testing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,8 @@ Imports:
     RcppRoll,
     scales,
     Rcpp,
-    ggforce
+    ggforce,
+    qlcMatrix
 Collate: 
     'RcppExports.R'
     'data.R'

--- a/R/links.R
+++ b/R/links.R
@@ -299,11 +299,11 @@ LinkPeaks <- function(
         return(list("gene" = NULL, "coef" = NULL, "zscore" = NULL))
       } else {
         peak.access <- peak.data[, peak.use]
-        coef.result <- cor(
-          x = as.matrix(x = peak.access),
-          y = as.matrix(x = gene.expression),
-          method = method
+        coef.result <- corSparse(
+          X = peak.access,
+          Y = gene.expression
         )
+        rownames(coef.result) <- colnames(peak.access)
         coef.result <- coef.result[abs(x = coef.result) > score_cutoff, , drop = FALSE]
 
         if (nrow(x = coef.result) == 0) {
@@ -332,11 +332,11 @@ LinkPeaks <- function(
           )
           # run background correlations
           bg.access <- peak.data[, unlist(x = bg.peaks)]
-          bg.coef <- cor(
-            x = as.matrix(x = bg.access),
-            y = as.matrix(x = gene.expression),
-            method = method
+          bg.coef <- corSparse(
+            X = bg.access,
+            Y = Matrix(gene.expression)
           )
+          rownames(bg.coef) <- colnames(bg.access)
           zscores <- vector(mode = "numeric", length = length(x = peaks.test))
           for (j in seq_along(along.with = peaks.test)) {
             coef.use <- bg.coef[(((j - 1) * n_sample) + 1):(j * n_sample), ]

--- a/R/links.R
+++ b/R/links.R
@@ -266,6 +266,12 @@ LinkPeaks <- function(
     genes = gene.coords.use,
     distance = distance
   )
+  if (sum(peak_distance_matrix) == 0) {
+    stop("No peaks fall within distance threshold\n",
+         "Have you set the proper genome and seqlevelsStyle for ",
+         peak.assay,
+         " assay?")
+  }
   genes.use <- colnames(x = peak_distance_matrix)
   all.peaks <- rownames(x = peak.data)
 

--- a/R/links.R
+++ b/R/links.R
@@ -292,19 +292,19 @@ LinkPeaks <- function(
     X = seq_along(along.with = genes.use),
     FUN = function(i) {
       peak.use <- as.logical(x = peak_distance_matrix[, genes.use[[i]]])
-      gene.expression <- expression.data[genes.use[[i]], ]
+      gene.expression <- t(x = expression.data[genes.use[[i]], , drop = FALSE])
       gene.chrom <- as.character(x = seqnames(x = gene.coords.use[i]))
 
       if (sum(peak.use) < 2) {
         # no peaks close to gene
         return(list("gene" = NULL, "coef" = NULL, "zscore" = NULL))
       } else {
-        peak.access <- peak.data[, peak.use]
+        peak.access <- peak.data[, peak.use, drop = FALSE]
         coef.result <- corSparse(
           X = peak.access,
           Y = gene.expression
         )
-        rownames(coef.result) <- colnames(peak.access)
+        rownames(x = coef.result) <- colnames(x = peak.access)
         coef.result <- coef.result[abs(x = coef.result) > score_cutoff, , drop = FALSE]
 
         if (nrow(x = coef.result) == 0) {
@@ -332,10 +332,10 @@ LinkPeaks <- function(
             }
           )
           # run background correlations
-          bg.access <- peak.data[, unlist(x = bg.peaks)]
+          bg.access <- peak.data[, unlist(x = bg.peaks), drop = FALSE]
           bg.coef <- corSparse(
             X = bg.access,
-            Y = Matrix(gene.expression)
+            Y = gene.expression
           )
           rownames(bg.coef) <- colnames(bg.access)
           zscores <- vector(mode = "numeric", length = length(x = peaks.test))

--- a/R/links.R
+++ b/R/links.R
@@ -187,6 +187,7 @@ ConnectionsToLinks <- function(conns, ccans = NULL, threshold = 0) {
 #' @importFrom future.apply future_lapply
 #' @importFrom future nbrOfWorkers
 #' @importFrom pbapply pblapply
+#' @importFrom qlcMatrix corSparse
 #' @importMethodsFrom Matrix t
 #'
 #' @return Returns a Seurat object with the \code{Links} information set, with


### PR DESCRIPTION
Hi Tim, first off thanks for this wonderfully useful package and its maintenance.

 I have a bit of niche pull request here. My workflow which led to my issue was as follows:

- I'm using 10x multiome data where the peak regions that were quantifying our ATAC data for come from an independent DNAse-seq experiment
- After performing all the initial clustering and WNN analysis, we opted to call peaks using macs2 on our ATACseq data and then quantified those macs2 peaks for further analysis and differential accessibility testing. Additionally we planned to quantify Peak-Gene linkage in the macs2 called peaks. 
- It was 100% an error on my part, but I never set the proper seqlevelsStyle and genome for the annotations tied to the macs2peak assay
- This lead to no overlaps between the two objects in the DistanceToTSS step of the LinkPeaks function. However there is only a warning and not an error that occurs at this step. And the resulting "peak_distance_matrix" is complete, but is a sparse matrix full of zeros
- What happens is there is never an error thrown, all peak-gene tests are performed (which takes several hours when done genome wide as I'm doing (~26,000 genes and ~120,000 peaks)) and the resulting message "No significant links found" is returned.

The error message I provided might not be exactly ideal, and I realize this was caused by my own error, but I think a sanity check to see if any peaks fall within the distance threshold before actually preforming all of the tests isn't a terrible idea.

I'd love to hear your opinions about this change or other checks along the way that may be more useful to implement rather than the way that I approached it.

Thanks!